### PR TITLE
Drop cssbeautify as dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
     "test": "grunt test"
   },
   "dependencies": {
-    "cssbeautify": "~0.3.1",
     "csscomb": "~3.0.0",
     "underscore": "~1.6.0"
   },

--- a/tasks/wpcss.js
+++ b/tasks/wpcss.js
@@ -12,7 +12,6 @@ module.exports = function( grunt ) {
 
 	var _ = require( 'underscore' ),
 		Comb = require( 'csscomb' ),
-		cssbeautify = require( 'cssbeautify' ),
 		fs = require( 'fs' ),
 		path = require( 'path' );
 
@@ -60,7 +59,6 @@ module.exports = function( grunt ) {
 				return grunt.file.read( filepath ).trim();
 			}).join( '\n\n' );
 
-			contents = cssbeautify( contents );
 			contents = comb.processString( contents );
 
 			if ( options.commentSpacing ) {

--- a/test/expected/comment-spacing.css
+++ b/test/expected/comment-spacing.css
@@ -9,8 +9,9 @@
 
 /* Rule comment */
 html {
-	box-sizing: border-box;
-	/* Inline comment. */
+	box-sizing: border-box; /* Inline comment using space */
+	/* Inline comment on own line */
+	color: #fff;	/* Inline comment using tab */
 }
 
 

--- a/test/fixtures/comment-spacing.css
+++ b/test/fixtures/comment-spacing.css
@@ -8,7 +8,11 @@
 }
 /* Rule comment */
 html {
-	box-sizing: border-box; /* Inline comment. */
+	box-sizing: border-box; /* Inline comment using space */
+
+	/* Inline comment on own line */
+
+	color: #fff;	/* Inline comment using tab */
 }
 
 


### PR DESCRIPTION
The only thing is was changing was forcing inline comments on to a new line, and that's
not necessarily what's needed. Consider some CSS which has inline comments indicating a line
specifically for certain versions of IE. Moving those to next lines would make the code less clear.

The unit test therefore has been updated to test how CSSComb handles inline comments next to a property
using a space separator, a tab separator and not next to a property.

Fixes #3
