### PR TITLE
Update peerDependencies to support Grunt 1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,12 +15,7 @@
   "bugs": {
     "url": "https://github.com/cedaro/grunt-wp-css/issues"
   },
-  "licenses": [
-    {
-      "type": "MIT",
-      "url": "https://github.com/cedaro/grunt-wp-css/blob/master/LICENSE-MIT"
-    }
-  ],
+  "license": "MIT",
   "engines": {
     "node": ">= 0.10.0"
   },
@@ -29,18 +24,18 @@
   },
   "dependencies": {
     "cssbeautify": "~0.3.1",
-    "csscomb": "~3.0.4",
-    "lodash": "~3.3.0"
+    "csscomb": "~3.1.5",
+    "lodash": "~3.9.2"
   },
   "devDependencies": {
     "grunt": "~0.4.5",
     "grunt-contrib-clean": "~0.6.0",
-    "grunt-contrib-jshint": "~0.11.0",
+    "grunt-contrib-jshint": "~0.11.2",
     "grunt-contrib-nodeunit": "~0.4.1",
     "matchdep": "~0.3.0"
   },
   "peerDependencies": {
-    "grunt": "~0.4"
+    "grunt": ">=0.4.0"
   },
   "keywords": [
     "gruntplugin",


### PR DESCRIPTION
Update peerDependencies to support Grunt 1.0

Hello,

This is an automated issue request to update the `peerDependencies` for your Grunt plugin.
We ask you to merge this and **publish a new release on npm** to get your plugin working in Grunt 1.0!

Read more here: http://gruntjs.com/blog/2016-02-11-grunt-1.0.0-rc1-released#peer-dependencies
Also on Twitter: https://twitter.com/gruntjs/status/700819604155707392

If you have any questions or you no longer have time to maintain this plugin, then please let us know in this thread.

Thanks for creating and working on this plugin!

(P.S. Close this PR if it is a mistake, sorry)
